### PR TITLE
Adds support for RedHat OS family.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,9 @@ jobs:
           # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
           # - ubuntu2204
           - ubuntu2004
+          - fedora40
+          - rockylinux8
+          - rockylinux9
 
     steps:
       - name: Check out the repository

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *.retry
-*/__pycache__
-*.pyc
-/.python-version
 
 # Visual Studio Code
 .vscode/
+
+# Python
+.venv
+*/__pycache__
+*.pyc
+/.python-version

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-fedora40}-ansible:latest"
     command: ${MOLECULE_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,28 @@
+---
+- name: Check if keyring exists
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/brave-browser-archive-keyring.gpg
+  register: keyring_file
+
+- name: Get keyring file
+  ansible.builtin.get_url:
+    url: https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+    dest: "/usr/share/keyrings/brave-browser-archive-keyring.gpg"
+    mode: "0644"
+  when: not keyring_file.stat.exists
+  become: true
+
+- name: Add Brave repository to list of repositories
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/brave-browser-release.list
+    content: |
+      deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main
+    mode: "0644"
+
+- name: Install Brave
+  ansible.builtin.apt:
+    name: brave-browser
+    state: present
+    update_cache: true
+  become: true

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Add Brave Browser repository
+  ansible.builtin.yum_repository:
+    name: brave-browser
+    description: Brave Browser Repository
+    baseurl: https://brave-browser-rpm-release.s3.brave.com/$basearch
+    enabled: true
+    gpgcheck: true
+    gpgkey: https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
+
+
+- name: Install Brave Browser
+  ansible.builtin.dnf:
+    name: brave-browser
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,4 @@
 ---
-- name: Check if keyring exists
-  ansible.builtin.stat:
-    path: /usr/share/keyrings/brave-browser-archive-keyring.gpg
-  register: keyring_file
-
-- name: Get keyring file
-  ansible.builtin.get_url:
-    url: https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-    dest: "/usr/share/keyrings/brave-browser-archive-keyring.gpg"
-    mode: "0644"
-  when: not keyring_file.stat.exists
-  become: true
-
-- name: Add Brave repository to list of repositories
-  become: true
-  ansible.builtin.copy:
-    dest: /etc/apt/sources.list.d/brave-browser-release.list
-    content: |
-      deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main
-    mode: "0644"
-
-- name: Install Brave
-  ansible.builtin.apt:
-    name: brave-browser
-    state: present
-    update_cache: true
-  become: true
+- name: Include tasks for target OS family
+  include_tasks: "{{ ansible_os_family }}.yml"
+      


### PR DESCRIPTION
Refactoring entry point to include tasks base on `ansible_os_family` and adding the following distros on test workflow:

- Fedora40
- RockyLinux8
- RockyLinux9